### PR TITLE
Update test settings, update djangocms-helper version, remove skip_missing_interpreters

### DIFF
--- a/test_requirements/base.txt
+++ b/test_requirements/base.txt
@@ -1,7 +1,7 @@
 coverage==3.7.1
 django-parler
 django-treebeard>=2.0
-djangocms-helper
+djangocms-helper>=0.9.1
 flake8
 python-coveralls==2.4.2
 six

--- a/test_settings.py
+++ b/test_settings.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
 HELPER_SETTINGS = {
     'SITE_ID': 1,
     'TIME_ZONE': 'Europe/Zurich',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,8 @@
 [tox]
-envlist = flake8, py{34,33,27}-dj{18,17,16}, py{26}-dj{16}
-skip_missing_interpreters = True
+envlist =
+    flake8
+    py{34,33,27}-dj{18,17,16}
+    py26-dj16
 
 [testenv]
 passenv =


### PR DESCRIPTION
Minor improvements in tests setup.

If you are running ``tox`` locally and want to avoid failures due to missing interpreters - please use command line args for tox ``--skip-missing-interpreters``
http://tox.readthedocs.org/en/latest/config.html#confval-skip_missing_interpreters=BOOL
Local setup should not affect ``Travis CI`` test failures.